### PR TITLE
Add `postStatus` method

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,4 +25,6 @@ dependencies {
     compileOnly group: 'javax.servlet', name: 'javax.servlet-api', version: '3.0.1'
     // https://mvnrepository.com/artifact/org.eclipse.jetty/jetty-server
     implementation group: 'org.eclipse.jetty', name: 'jetty-server', version: '10.0.13'
+    // https://mvnrepository.com/artifact/org.json/json
+    implementation group: 'org.json', name: 'json', version: '20220924'
 }

--- a/src/main/java/com/ci/ContinuousIntegrationServer.java
+++ b/src/main/java/com/ci/ContinuousIntegrationServer.java
@@ -67,8 +67,18 @@ public class ContinuousIntegrationServer extends AbstractHandler
     private void build() {
 
     }
-    
-    private void postStatus(CommitStatus status, String description) throws Exception {
+
+    /**
+     * Set the commmit status for the current repository and SHA specified by the `repOwner`, `repName`, and ``sha` fields.
+     * @param status the status of the commit message
+     * @param description a more helpful description of the status
+     * @throws Exception if the request response is not 200.
+     * @throws Error if the necessary fields are not all set.
+     */
+    private void postStatus(CommitStatus status, String description) throws Exception, Error {
+        if (repOwner == null || repName == null || sha == null) {
+            throw new Error("One or more of the necessary fields `repOwner`, `repName`, and `sha` is not set.");
+        }
         // API enpoint for setting the commit status  
         URL url = new URL(String.format("https://api.github.com/repos/%s/%s/statuses/%s", repOwner, repName, sha));
         HttpsURLConnection con = (HttpsURLConnection) url.openConnection();

--- a/src/main/java/com/ci/ContinuousIntegrationServer.java
+++ b/src/main/java/com/ci/ContinuousIntegrationServer.java
@@ -23,11 +23,11 @@ public class ContinuousIntegrationServer extends AbstractHandler
     final static int GROUP_NUMBER = 31;
     final static int PORT = 8000 + GROUP_NUMBER;
 
-    private final static String TOKEN;
+    private String TOKEN;
 
-    String repOwner;
-    String repName;
-    String sha;
+    private String repOwner;
+    private String repName;
+    private String sha;
 
     enum CommitStatus {
         error,
@@ -35,6 +35,8 @@ public class ContinuousIntegrationServer extends AbstractHandler
         pending,
         success
     }
+
+    
 
     public void handle(String target,
                        Request baseRequest,

--- a/src/main/java/com/ci/ContinuousIntegrationServer.java
+++ b/src/main/java/com/ci/ContinuousIntegrationServer.java
@@ -96,7 +96,6 @@ public class ContinuousIntegrationServer extends AbstractHandler
         JSONObject body = new JSONObject();
         body.put("state", status.toString());
         body.put("description", description);
-        System.out.println(body.toString());
         
         DataOutputStream out = new DataOutputStream(con.getOutputStream());
         out.writeBytes(body.toString());

--- a/src/main/java/com/ci/ContinuousIntegrationServer.java
+++ b/src/main/java/com/ci/ContinuousIntegrationServer.java
@@ -2,10 +2,13 @@ package com.ci;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.net.ssl.HttpsURLConnection;
 import javax.servlet.ServletException;
- 
+
+import java.io.DataOutputStream;
 import java.io.IOException;
- 
+import java.net.URL;
+
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.handler.AbstractHandler;
@@ -18,6 +21,17 @@ public class ContinuousIntegrationServer extends AbstractHandler
 {  
     final static int GROUP_NUMBER = 31;
     final static int PORT = 8000 + GROUP_NUMBER;
+
+    String repOwner;
+    String repName;
+    String sha;
+
+    enum CommitStatus {
+        error,
+        failure,
+        pending,
+        success
+    }
     
     public void handle(String target,
                        Request baseRequest,
@@ -53,9 +67,31 @@ public class ContinuousIntegrationServer extends AbstractHandler
     private void build() {
 
     }
+    
+    private void postStatus(CommitStatus status, String description) throws Exception {
+        // API enpoint for setting the commit status  
+        URL url = new URL(String.format("https://api.github.com/repos/%s/%s/statuses/%s", repOwner, repName, sha));
+        HttpsURLConnection con = (HttpsURLConnection) url.openConnection();
+        con.setRequestMethod("POST");
+        con.setRequestProperty("accept", "application/vnd.github+json"); // Recommended header
+        con.setDoOutput(true);
+        DataOutputStream out = new DataOutputStream(con.getOutputStream());
 
-    private void report() {
+        // Add status and description to body:
+        out.writeBytes(String.format("\"status\":\"%s\", \"description\":\"%d\"", status, description));
+        out.flush();
+        out.close();
 
+        // Send request
+        con.connect();
+
+        // Check response code
+        int code = con.getResponseCode();
+        if (code != 200) {
+            System.out.println(String.format("Error when setting commit status! (%d)", code));
+            throw new Exception(con.getResponseMessage());
+        }
+        con.disconnect();
     }
 
     private void cleanup() {


### PR DESCRIPTION
Fixes #8 

This PR adds a method `postStatus` that sends a POST request to Githubs "create commit status"-endpoint.

The `postStatus` is more general than the at first proposed `report` method since we might want to set the status multiple times during a push, e.g. setting the status to "pending" at the begining and then setting it to either "failure", "error", or "success" at the end. 