### PR TITLE
Add pull and checkout feature

### DIFF
--- a/src/main/java/com/ci/ContinuousIntegrationServer.java
+++ b/src/main/java/com/ci/ContinuousIntegrationServer.java
@@ -84,7 +84,7 @@ public class ContinuousIntegrationServer extends AbstractHandler {
 
         try {
             // Update target repository and checkout to the correct branch.
-            this.updateTarget();
+            repository = GitUtils.updateTarget(repoCloneURL, branch);
             // Build the cloneld repository
             this.build();
         } catch (Exception e) {
@@ -124,56 +124,6 @@ public class ContinuousIntegrationServer extends AbstractHandler {
     //Method for JUnit to initially try
     public void gradleTest(){
         System.out.println("Gradle/JUnit works");
-    }
- 
-    /**
-     * Clones the git repository specified by <code>repoCloneURL</code> into the directory specified by <code>DIR_PATH</code>.
-     * @param repoCloneURL The URL of the git repository to clone.
-     * @throws Exception if an error occours when cloning the repository.
-     */
-    private void cloneRepo() throws Exception {
-        try {
-            repository = Git.cloneRepository()
-                .setURI(repoCloneURL)
-                .setDirectory(new File(DIR_PATH))
-                .setCloneAllBranches(true)
-                .call();
-        } catch (Exception e) {
-            // TODO: Better error handling?
-            throw new Exception("Error encountered in `cloneRepo`");
-        }
-    }
-
-    /**
-     * Pull the repository declared in the <code>repository</code> field and checkout to the branch specified by the <code>branch</code> field.
-     * @throws Exception if an error occours when either pulling or branching.
-     */
-    private void pullAndBranch() throws Exception {
-        try {
-            repository.pull().call();
-            repository.checkout().addPath("origin/" + branch).call();
-        } catch (Exception e) {
-            // TODO: Better error handling?
-            e.printStackTrace();
-            throw new Exception("Error encountered in `pullAndBranch`");
-        }
-        
-    }
-
-    /**
-     * Update the target repository either by pulling the main branch or cloning the repository.
-     * Then checkout to the branch specified by the <code>branch</code> field.
-     * 
-     * @throws Exception 
-     */
-    private void updateTarget() throws Exception {
-        File gitDir = new File(DIR_PATH + "/.git");
-        try {
-            repository = Git.open(gitDir);     
-        } catch (IOException e) {
-            this.cloneRepo();
-        }
-        this.pullAndBranch();
     }
 
     /**

--- a/src/main/java/com/ci/ContinuousIntegrationServer.java
+++ b/src/main/java/com/ci/ContinuousIntegrationServer.java
@@ -24,11 +24,7 @@ import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-//import org.eclipse.jgit.*;
 import org.eclipse.jgit.api.Git;
-import org.eclipse.jgit.api.errors.GitAPIException;
-import org.eclipse.jgit.api.errors.InvalidRemoteException;
-import org.eclipse.jgit.api.errors.TransportException;
 
 /** 
  Skeleton of a ContinuousIntegrationServer which acts as webhook
@@ -87,15 +83,20 @@ public class ContinuousIntegrationServer extends AbstractHandler {
         postStatus(CommitStatus.pending, "Building repository and running tests...");
 
         try {
-            // Download target repository
-            this.cloneRepo();
+            // Update target repository and checkout to the correct branch.
+            this.updateTarget();
             // Build the cloneld repository
             this.build();
-        } catch (InterruptedException | JSONException | GitAPIException e) {
+        } catch (Exception e) {
             e.printStackTrace();
             postStatus(CommitStatus.error, "CI server encountered an error");
             response.getWriter().println("Server error");
             response.setStatus(500);
+
+            // Close the repository if we're returning early
+            if (repository != null) {
+                repository.close();
+            }
             return;
         }
         
@@ -111,7 +112,7 @@ public class ContinuousIntegrationServer extends AbstractHandler {
             default:
                 postStatus(CommitStatus.success, "Build complete and all tests passed");
         }
-
+        repository.close();
         response.getWriter().println("CI job done");
     }
 
@@ -126,20 +127,54 @@ public class ContinuousIntegrationServer extends AbstractHandler {
     }
  
     /**
-     * Clones the git repository specified by repoCloneURL into the directory specified by dirPath.
+     * Clones the git repository specified by <code>repoCloneURL</code> into the directory specified by <code>DIR_PATH</code>.
      * @param repoCloneURL The URL of the git repository to clone.
-     * @return The exit value of the "git clone repoName dirPath" command.
-     * @throws InvalidRemoteException
-     * @throws TransportException
-     * @throws GitAPIException
+     * @throws Exception if an error occours when cloning the repository.
      */
-    private void cloneRepo() throws InvalidRemoteException, TransportException, JSONException, GitAPIException {
-        repository = Git.cloneRepository()
-            .setURI(repoCloneURL)
-            .setDirectory(new File(DIR_PATH))
-            .call();
+    private void cloneRepo() throws Exception {
+        try {
+            repository = Git.cloneRepository()
+                .setURI(repoCloneURL)
+                .setDirectory(new File(DIR_PATH))
+                .setCloneAllBranches(true)
+                .call();
+        } catch (Exception e) {
+            // TODO: Better error handling?
+            throw new Exception("Error encountered in `cloneRepo`");
+        }
     }
 
+    /**
+     * Pull the repository declared in the <code>repository</code> field and checkout to the branch specified by the <code>branch</code> field.
+     * @throws Exception if an error occours when either pulling or branching.
+     */
+    private void pullAndBranch() throws Exception {
+        try {
+            repository.pull().call();
+            repository.checkout().addPath("origin/" + branch).call();
+        } catch (Exception e) {
+            // TODO: Better error handling?
+            e.printStackTrace();
+            throw new Exception("Error encountered in `pullAndBranch`");
+        }
+        
+    }
+
+    /**
+     * Update the target repository either by pulling the main branch or cloning the repository.
+     * Then checkout to the branch specified by the <code>branch</code> field.
+     * 
+     * @throws Exception 
+     */
+    private void updateTarget() throws Exception {
+        File gitDir = new File(DIR_PATH + "/.git");
+        try {
+            repository = Git.open(gitDir);     
+        } catch (IOException e) {
+            this.cloneRepo();
+        }
+        this.pullAndBranch();
+    }
 
     /**
      * Builds the branch that was cloned into the target directory.

--- a/src/main/java/com/ci/GitUtils.java
+++ b/src/main/java/com/ci/GitUtils.java
@@ -1,0 +1,72 @@
+package com.ci;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.eclipse.jgit.api.Git;
+
+/**
+ * Various utility functions for Git stuff.
+ */
+public class GitUtils {
+    /**
+     * Clones a git specified repository by into the directory specified by <code>DIR_PATH</code>.
+     * 
+     * @param url The URL of the git repository to clone.
+     * @return the created <code>Git</code> object.
+     * @throws Exception if an error occours when cloning the repository.
+     */
+    public static Git cloneRepo(String url) throws Exception {
+        try {
+            Git repository = Git.cloneRepository()
+                .setURI(url)
+                .setDirectory(new File(ContinuousIntegrationServer.DIR_PATH))
+                .setCloneAllBranches(true)
+                .call();
+            return repository;
+        } catch (Exception e) {
+            // TODO: Better error handling?
+            throw new Exception("Error encountered in `cloneRepo`");
+        }
+    }
+
+    /**
+     * Pull the repository declared in the <code>repository</code> field and 
+     * checkout to the branch specified by the <code>branch</code> field.
+     * 
+     * @param repository the repository to update and checkout.
+     * @param branch the name of the branch to checkout. 
+     * @throws Exception if an error occours when either pulling or branching.
+     */
+    public static void pullAndBranch(Git repository, String branch) throws Exception {
+        try {
+            repository.pull().call();
+            repository.checkout().addPath("origin/" + branch).call();
+        } catch (Exception e) {
+            // TODO: Better error handling?
+            e.printStackTrace();
+            throw new Exception("Error encountered in `pullAndBranch`");
+        }
+        
+    }
+
+    /**
+     * Update the target repository either by pulling the main branch or cloning the repository.
+     * Then checkout to the specified branch.
+     * 
+     * @param url the clone URL of the repository.
+     * @param branch the name of the branch to chekcout.
+     * @throws Exception 
+     */
+    public static Git updateTarget(String url, String branch) throws Exception {
+        File gitDir = new File(ContinuousIntegrationServer.DIR_PATH + "/.git");
+        Git repository;
+        try {
+            repository = Git.open(gitDir);     
+        } catch (IOException e) {
+            repository = cloneRepo(url);
+        }
+        pullAndBranch(repository, branch);
+        return repository;
+    }
+}


### PR DESCRIPTION
Fixes #28 

- Adds a method that pulls the master and then checkouts to a specific remote branch.
- Moves these methods to a separate utility class for separation of concerns.

Everything should work, but I'm not entirely sure since I haven't tested with the implemented `analyzeTests`-method.