### PR TITLE
Fix checkout bug

### DIFF
--- a/src/main/java/com/ci/ContinuousIntegrationServer.java
+++ b/src/main/java/com/ci/ContinuousIntegrationServer.java
@@ -42,6 +42,7 @@ public class ContinuousIntegrationServer extends AbstractHandler {
     final static String testXMLDIR_PATH = DIR_PATH + "/build/test-results/test/";
 
     final private String TOKEN;
+    final private String MAIN_BRANCH;
 
     private String repOwner;
     private String repName;
@@ -65,8 +66,9 @@ public class ContinuousIntegrationServer extends AbstractHandler {
         testFail
     }
 
-    public ContinuousIntegrationServer(String statusToken) {
+    public ContinuousIntegrationServer(String statusToken, String mainBranch) {
         TOKEN = statusToken;
+        MAIN_BRANCH = mainBranch;
     }
 
     public void handle(String target,
@@ -104,7 +106,7 @@ public class ContinuousIntegrationServer extends AbstractHandler {
 
         try {
             // Update target repository and checkout to the correct branch.
-            repository = GitUtils.updateTarget(repoCloneURL, branch);
+            repository = GitUtils.updateTarget(repoCloneURL, branch, MAIN_BRANCH);
             // Build the cloneld repository
             this.build();
         } catch (Exception e) {
@@ -279,8 +281,9 @@ public class ContinuousIntegrationServer extends AbstractHandler {
         JSONObject conf = new JSONObject(Files.readString(Path.of("config.json")));
         int port = conf.getInt("port");
         String statusToken = conf.getString("status-token");
+        String mainBranch = conf.getString("main-branch");
         Server server = new Server(port);
-        server.setHandler(new ContinuousIntegrationServer(statusToken)); 
+        server.setHandler(new ContinuousIntegrationServer(statusToken, mainBranch)); 
         server.start();
         server.join();
     }

--- a/src/main/java/com/ci/GitUtils.java
+++ b/src/main/java/com/ci/GitUtils.java
@@ -36,12 +36,14 @@ public class GitUtils {
      * 
      * @param repository the repository to update and checkout.
      * @param branch the name of the branch to checkout. 
+     * @param mainBranch the name of the main branch for the repository.
      * @throws Exception if an error occours when either pulling or branching.
      */
-    public static void pullAndBranch(Git repository, String branch) throws Exception {
+    public static void pullAndBranch(Git repository, String branch, String mainBranch) throws Exception {
         try {
+            repository.checkout().setName(mainBranch).call();
             repository.pull().call();
-            repository.checkout().addPath("origin/" + branch).call();
+            repository.checkout().setName("origin/" + branch).call();
         } catch (Exception e) {
             // TODO: Better error handling?
             e.printStackTrace();
@@ -56,9 +58,10 @@ public class GitUtils {
      * 
      * @param url the clone URL of the repository.
      * @param branch the name of the branch to chekcout.
+     * @param mainBranch the name of the main branch for the repository
      * @throws Exception 
      */
-    public static Git updateTarget(String url, String branch) throws Exception {
+    public static Git updateTarget(String url, String branch, String mainBranch) throws Exception {
         File gitDir = new File(ContinuousIntegrationServer.DIR_PATH + "/.git");
         Git repository;
         try {
@@ -66,7 +69,7 @@ public class GitUtils {
         } catch (IOException e) {
             repository = cloneRepo(url);
         }
-        pullAndBranch(repository, branch);
+        pullAndBranch(repository, branch, mainBranch);
         return repository;
     }
 }

--- a/src/test/java/com/ci/ContinuousIntegrationServerTest.java
+++ b/src/test/java/com/ci/ContinuousIntegrationServerTest.java
@@ -6,7 +6,7 @@ import java.io.IOException;
 
 public class ContinuousIntegrationServerTest {
 
-        ContinuousIntegrationServer DEFAULT = new ContinuousIntegrationServer("");
+        ContinuousIntegrationServer DEFAULT = new ContinuousIntegrationServer("", "master");
         //Example: Typical test syntax
         @Test
         public void verifyNoExceptionsThrown(){


### PR DESCRIPTION
Fixes #45 

There were two bugs in the previous implementation:
- The `addPaths`-method wasn't correct which lead to the command not checkout out. This was changed to `setName` which seems to be the correct way of specifying the branch.
- After receiving a request, we never checked out to the main branch. This meant that at the next request, we pulled the previously visited branch instead of the main branch.

Since this fix needs the name of the main branch, I added it as a requirement for the config file.