### PR TITLE
Fix `handle` method

### DIFF
--- a/src/main/java/com/ci/ContinuousIntegrationServer.java
+++ b/src/main/java/com/ci/ContinuousIntegrationServer.java
@@ -81,8 +81,6 @@ public class ContinuousIntegrationServer extends AbstractHandler {
         response.setContentType("text/html;charset=utf-8");
         response.setStatus(HttpServletResponse.SC_OK);
         baseRequest.setHandled(true);
-        
-        System.out.println(target);
 
         pushRequest = new JSONObject(request.getReader().lines().collect(Collectors.joining()));
 
@@ -92,8 +90,11 @@ public class ContinuousIntegrationServer extends AbstractHandler {
         repoCloneURL = pushRequest.getJSONObject("repository").getString("clone_url");
         branch = pushRequest.getString("ref").split("/")[2];
 
+        System.out.println("Processing request on branch \"" + branch + "\"");
+
         // Respond to the Github servers before building anything:
         if (sha.matches("^0+$")) {
+            System.out.println("\tMerge commit, aborting");
             response.getWriter().println("SHA was zero, no build was tested.");
             return;
         } else {
@@ -106,10 +107,12 @@ public class ContinuousIntegrationServer extends AbstractHandler {
 
         // Set pending status
         postStatus(CommitStatus.pending, "Building repository and running tests...");
+        System.out.println("\tSet commit status to pending");
 
         try {
             // Update target repository and checkout to the correct branch.
             repository = GitUtils.updateTarget(repoCloneURL, branch, MAIN_BRANCH);
+            System.out.println("\tUpdated target repository, building project...");
             // Build the cloneld repository
             this.build();
         } catch (Exception e) {
@@ -122,7 +125,7 @@ public class ContinuousIntegrationServer extends AbstractHandler {
             }
             return;
         }
-        
+        System.out.println("\tBuild complete, analyzing test result...");
         BuildStatus res = analyzeResults();
         switch (res) {
             case buildFail:
@@ -134,6 +137,12 @@ public class ContinuousIntegrationServer extends AbstractHandler {
             default:
                 postStatus(CommitStatus.success, "Build complete and all tests passed");
         }
+        
+        //Build complete, remove the `build` folder
+        System.out.println("\tBuild-analyzis complete, removing the build-directory...");
+        cleanBuild();
+        System.out.println("\tBuild-directory successfully removed.");
+
         repository.close();
     }
 

--- a/src/main/java/com/ci/GitUtils.java
+++ b/src/main/java/com/ci/GitUtils.java
@@ -67,6 +67,11 @@ public class GitUtils {
         try {
             repository = Git.open(gitDir);     
         } catch (IOException e) {
+            // If the target folder exists but has weird stuff in it, delete it.
+            if (new File(ContinuousIntegrationServer.DIR_PATH).isDirectory()) {
+                ContinuousIntegrationServer.cleanTarget();
+            }
+            System.out.println("\tNo git repository found, cloning from url...");
             repository = cloneRepo(url);
         }
         pullAndBranch(repository, branch, mainBranch);


### PR DESCRIPTION
Fixes #41 
Fix the handle method such that it cleans the build directory. Also added some prints for the server terminal.


Co-authored-by: Jonas Sävås <Jonassavas@users.noreply.github.com>