### PR TITLE
Add tests for `postStatus`

### DIFF
--- a/src/main/java/com/ci/ContinuousIntegrationServer.java
+++ b/src/main/java/com/ci/ContinuousIntegrationServer.java
@@ -45,9 +45,9 @@ public class ContinuousIntegrationServer extends AbstractHandler {
     final private String TOKEN;
     final private String MAIN_BRANCH;
 
-    private String repOwner;
-    private String repName;
-    private String sha;
+    String repOwner;
+    String repName;
+    String sha;
     private String repoCloneURL;
     private String branch;
     
@@ -159,10 +159,11 @@ public class ContinuousIntegrationServer extends AbstractHandler {
      * 
      * @param status the status of the commit message
      * @param description a more helpful description of the status
-     * @throws IOException if the request response is not <code>201</code>.
-     * @throws Error if all neccessary fields are not set. 
+     * @throws IOException
+     * @throws Error if all neccessary fields are not set.
+     * @return the response code for the post request.
      */
-    private void postStatus(CommitStatus status, String description) throws IOException, Error {
+    public int postStatus(CommitStatus status, String description) throws IOException, Error {
         if (repOwner == null || repName == null || sha == null) {
             throw new Error("One or more of the necessary fields `repOwner`, `repName`, and `sha` is not set.");
         }
@@ -192,9 +193,10 @@ public class ContinuousIntegrationServer extends AbstractHandler {
         int code = con.getResponseCode();
         if (code != 201) {
             System.out.println(String.format("Error when setting commit status! (%d)", code));
-            throw new IOException(con.getResponseMessage());
+            System.out.println(con.getResponseMessage());
         }
         con.disconnect();
+        return code;
     }
 
     /**

--- a/src/test/java/com/ci/PostStatusTests.java
+++ b/src/test/java/com/ci/PostStatusTests.java
@@ -1,0 +1,61 @@
+package com.ci;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+import javax.servlet.http.HttpServletResponse;
+
+import com.ci.ContinuousIntegrationServer.CommitStatus;
+
+/**
+ * Tests written for the `postStatus method`
+ */
+public class PostStatusTests {
+
+    @Test
+    /**
+     * If <code>postStatues</code> cannot make a request, it should throw an <code>Error</code>.
+     * Contract:
+     *      Preconditions:  The fields required to make a status post request are not set.
+     *      Postcondition:  The method throws an <code>Error</code>
+     */
+    public void errorWithNullFields() {
+        var ci = new ContinuousIntegrationServer("", "master");
+        assertThrows(
+            Error.class, 
+            () -> ci.postStatus(CommitStatus.success, "Hello World!")
+        );
+        ci.repOwner = "DD2480-Group31";
+        assertThrows(
+            Error.class, 
+            () -> ci.postStatus(CommitStatus.success, "Hello World!")
+        );
+        ci.repName = "Continuous-Integration";
+        assertThrows(
+            Error.class, 
+            () -> ci.postStatus(CommitStatus.success, "Hello World!")
+        );
+    }
+
+    @Test
+    /**
+     * Test that Github recieves the request. 
+     * Since we don't have an access token here, the response code should be 401.
+     * 
+     * Contract:
+     *      Precondition:   The required fields are set but the server lacks an access token.
+     *      Postcondition:  The method gets a response with error code 401 (unauthorized).
+     */
+    public void getsResponse() {
+        var ci = new ContinuousIntegrationServer("", "master");
+        ci.repOwner = "DD2480-Group31";
+        ci.repName = "Continuous-Integration";
+        ci.sha = "1b69dbad8b8818b80d0a4e70127d5ef27ed7198d"; // This is valid commit
+        try {
+            int code = ci.postStatus(CommitStatus.success, "This is a test");
+            assertEquals(HttpServletResponse.SC_UNAUTHORIZED, code);
+        } catch (Exception e) {
+            assertTrue("postStatus should not throw", false);
+        }   
+    }
+}


### PR DESCRIPTION
Fixes #53 

Adds two tests for the `postStatus` method and changes the signature of it to be tested more properly.
- One that tests that the function throws an error when not initialized properly.
- One that checks that we get a response from the Github server.
  - Since we can't have an access token ion the test, it only checks that we get a 401 (unauthorized) response code.